### PR TITLE
Update CP437.hs

### DIFF
--- a/Codec/Archive/Zip/CP437.hs
+++ b/Codec/Archive/Zip/CP437.hs
@@ -17,16 +17,15 @@ import Data.ByteString (ByteString)
 import Data.Char
 import Data.Monoid
 import Data.Text (Text)
-import Data.Text.Lazy (toStrict)
 import Data.Word (Word8)
 import qualified Data.ByteString        as B
-import qualified Data.Text.Lazy.Builder as LB
+import qualified Data.Text as T
 
 -- | Decode a 'ByteString' containing CP 437 encoded text.
 
 decodeCP437 :: ByteString -> Text
-decodeCP437 = toStrict . LB.toLazyText . B.foldl' f mempty
-  where f xs b = xs <> LB.singleton (decodeByteCP437 b)
+decodeCP437 = T.unfoldr (fmap (\(b,rest) -> (decodeByteCP437 b, rest)) . B.uncons)
+
 
 -- | Decode single byte of CP437 encoded text.
 

--- a/Codec/Archive/Zip/CP437.hs
+++ b/Codec/Archive/Zip/CP437.hs
@@ -15,7 +15,6 @@ where
 
 import Data.ByteString (ByteString)
 import Data.Char
-import Data.Monoid
 import Data.Text (Text)
 import Data.Word (Word8)
 import qualified Data.ByteString        as B
@@ -24,9 +23,12 @@ import qualified Data.Text as T
 -- | Decode a 'ByteString' containing CP 437 encoded text.
 
 decodeCP437 :: ByteString -> Text
-decodeCP437 = T.unfoldr (fmap (\(b,rest) -> (decodeByteCP437 b, rest)) . B.uncons)
-
-
+decodeCP437 bs = T.unfoldrN 
+  (B.length bs) 
+  (fmap (\(b,rest) -> (decodeByteCP437 b, rest)) . B.uncons)
+  bs
+        
+        
 -- | Decode single byte of CP437 encoded text.
 
 decodeByteCP437 :: Word8 -> Char


### PR DESCRIPTION
One is supposed to accumulate a builder with a right fold. https://www.reddit.com/r/haskell/comments/35udfy/fixing_an_aeson_performance_bug_sometimes_the_old/cr94pdj 
I skipped that with this attempt, which unfolds the text directly. It seems 10 or more times as fast if I send /usr/share/dict/words through it. `unfoldr` is a pretty strong function with text since it is basically just replicates  the stream representation. But maybe there is something better.