### PR TITLE
Zip64

### DIFF
--- a/Codec/Archive/Zip/Internal.hs
+++ b/Codec/Archive/Zip/Internal.hs
@@ -871,9 +871,10 @@ renameKey ok nk m = case M.lookup ok m of
 
 withSaturation :: forall a b. (Integral a, Integral b, Bounded b) => a -> b
 withSaturation x =
-  if fromIntegral x > (maxBound :: b)
-    then maxBound :: b
+  if (fromIntegral x :: Integer) > (fromIntegral bound :: Integer)
+    then bound
     else fromIntegral x
+  where bound = maxBound :: b
 
 -- | Determine target entry of action.
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-7.14
+resolver: lts-6.27
 packages:
 - '.'

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
-resolver: lts-6.27
+resolver: lts-7.14
 packages:
 - '.'


### PR DESCRIPTION
Fixes #30. After this change, a jar file with 114,143 files that was corrupt before is now valid and even `java` is succeeding without throwing exceptions. 

Basically what happens is that `withSaturation` does not do what's intended and produces and invalid central directory entry, but not so invalid that a smart zip tool can't bypass.  Basically, when you convert from `Natural` to `Word16` to write the number of entries in the central directory, it truncates the value, effectively ensuring the the condition in `withSaturation` is *always* false, and hence the truncated value is written. Meaning if the number of entries > 65,535, the truncated value will be written into the CD instead of `0xffff`.