### PR TITLE
Blind archive - continued

### DIFF
--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -98,6 +98,7 @@ module Codec.Archive.Zip
   , createArchive
   , createBlindArchive
   , withArchive
+  , withBlindArchive
     -- * Retrieving information
   , getEntries
   , doesEntryExist

--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -222,7 +222,7 @@ withBlindArchive h m = do
       action = unZipArchive (liftM2 const m commit)
   liftIO (evalStateT action st)
 
-
+ 
 
 
 

--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -96,7 +96,6 @@ module Codec.Archive.Zip
     -- * Archive monad
   , ZipArchive
   , createArchive
-  , createBlindArchive
   , withArchive
     -- * Retrieving information
   , getEntries
@@ -157,7 +156,6 @@ import qualified Data.Conduit.List          as CL
 import qualified Data.Map.Strict            as M
 import qualified Data.Sequence              as S
 import qualified Data.Set                   as E
-import System.IO
 
 ----------------------------------------------------------------------------
 -- Archive monad
@@ -180,7 +178,7 @@ newtype ZipArchive a = ZipArchive
 -- | Internal state record used by the 'ZipArchive' monad.
 
 data ZipState = ZipState
-  { zsFilePath  :: Either Handle (Path Abs File)
+  { zsFilePath  :: Path Abs File
     -- ^ Absolute path to zip archive
   , zsEntries   :: Map EntrySelector EntryDescription
     -- ^ Actual collection of entries
@@ -190,46 +188,6 @@ data ZipState = ZipState
     -- ^ Pending actions
   }
 
-
-
-
-createBlindArchive :: (MonadIO m, MonadCatch m)
-  => Handle    
-  -> ZipArchive a      -- ^ Actions that form archive's content
-  -> m a
-createBlindArchive h m = do
-  let st = ZipState
-        { zsFilePath = Left h
-        , zsEntries  = M.empty
-        , zsArchive  = ArchiveDescription Nothing 0 0
-        , zsActions  = S.empty }
-      action = unZipArchive (liftM2 const m commit)
-  liftIO $ hSetFileSize h 0 -- Truncate the file
-        *> evalStateT action st
-
-
-withBlindArchive :: (MonadIO m, MonadThrow m)
-  => Handle      
-  -> ZipArchive a      -- ^ Actions on that archive
-  -> m a
-withBlindArchive h m = do
-  (desc, entries) <- liftIO (I.scanArchive (Left h))
-  let st = ZipState
-        { zsFilePath = Left h
-        , zsEntries  = entries
-        , zsArchive  = desc
-        , zsActions  = S.empty }
-      action = unZipArchive (liftM2 const m commit)
-  liftIO (evalStateT action st)
-
-
-
-
-
-
-
-
-              
 -- | Create new archive given its location and action that describes how to
 -- create content in the archive. This will silently overwrite specified
 -- file if it already exists. See 'withArchive' if you want to work with
@@ -243,7 +201,7 @@ createArchive path m = do
   apath <- makeAbsolute path
   ignoringAbsence (removeFile apath)
   let st = ZipState
-        { zsFilePath = Right apath
+        { zsFilePath = apath
         , zsEntries  = M.empty
         , zsArchive  = ArchiveDescription Nothing 0 0
         , zsActions  = S.empty }
@@ -281,9 +239,9 @@ withArchive :: (MonadIO m, MonadThrow m)
   -> m a
 withArchive path m = do
   apath           <- canonicalizePath path
-  (desc, entries) <- liftIO (I.scanArchive (Right apath))
+  (desc, entries) <- liftIO (I.scanArchive apath)
   let st = ZipState
-        { zsFilePath = Right apath
+        { zsFilePath = apath
         , zsEntries  = entries
         , zsArchive  = desc
         , zsActions  = S.empty }
@@ -342,18 +300,11 @@ getEntrySource
   :: EntrySelector
   -> ZipArchive (Source (ResourceT IO) ByteString)
 getEntrySource s = do
-  given  <- getFilePath
-  case given of
-    Left _ ->  do
-      mdesc <- M.lookup s <$> getEntries
-      case mdesc of
-        Nothing   -> throwM (EntryDoesNotExist I.blindPath s)
-        Just desc -> return (I.sourceEntry I.blindPath desc True)
-    Right path -> do
-      mdesc <- M.lookup s <$> getEntries
-      case mdesc of
-        Nothing   -> throwM (EntryDoesNotExist path s)
-        Just desc -> return (I.sourceEntry path desc True)
+  path  <- getFilePath
+  mdesc <- M.lookup s <$> getEntries
+  case mdesc of
+    Nothing   -> throwM (EntryDoesNotExist path s)
+    Just desc -> return (I.sourceEntry path desc True)
 
 -- | Stream contents of archive entry to specified 'Sink'.
 --
@@ -594,20 +545,18 @@ undoAll = modifyActions (const S.empty)
 
 commit :: ZipArchive ()
 commit = do
-  given    <- getFilePath
+  file     <- getFilePath
   odesc    <- getArchiveDescription
   oentries <- getEntries
   actions  <- getPending
-  exists   <- case given of
-                Left _ -> pure True
-                Right file -> doesFileExist file
+  exists   <- doesFileExist file
   unless (S.null actions && exists) $ do
-    liftIO (I.commit given odesc oentries actions)
+    liftIO (I.commit file odesc oentries actions)
     -- NOTE The most robust way to update internal description of the
     -- archive is to scan it again — manual manipulations with descriptions
     -- of entries are too error-prone. We also want to erase all pending
     -- actions because 'I.commit' executes them all by definition.
-    (ndesc, nentries) <- liftIO (I.scanArchive given)
+    (ndesc, nentries) <- liftIO (I.scanArchive file)
     ZipArchive . modify $ \st -> st
       { zsEntries = nentries
       , zsArchive = ndesc
@@ -618,7 +567,7 @@ commit = do
 
 -- | Get path of actual archive file from inside of 'ZipArchive' monad.
 
-getFilePath :: ZipArchive (Either Handle (Path Abs File))
+getFilePath :: ZipArchive (Path Abs File)
 getFilePath = ZipArchive (gets zsFilePath)
 
 -- | Get collection of pending actions.

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,23 @@
+{ mkDerivation, base, bytestring, bzlib-conduit, case-insensitive
+, cereal, conduit, conduit-extra, containers, criterion, digest
+, exceptions, filepath, hspec, mtl, path, path-io, plan-b
+, QuickCheck, resourcet, stdenv, text, time, transformers
+}:
+mkDerivation {
+  pname = "zip";
+  version = "0.1.3";
+  src = ./.;
+  libraryHaskellDepends = [
+    base bytestring bzlib-conduit case-insensitive cereal conduit
+    conduit-extra containers digest exceptions filepath mtl path
+    path-io plan-b resourcet text time transformers
+  ];
+  testHaskellDepends = [
+    base bytestring conduit containers exceptions filepath hspec path
+    path-io QuickCheck text time transformers
+  ];
+  benchmarkHaskellDepends = [ base criterion ];
+  homepage = "https://github.com/mrkkrp/zip";
+  description = "Operations on zip archives";
+  license = stdenv.lib.licenses.bsd3;
+}


### PR DESCRIPTION
As I get time, I will try to slowly address the comments on the original PR and then fix the merge conflict.

I added the default.nix on this branch as well. I tested the default.nix using https://github.com/databrary/databrary-dev-learning/blob/master/reflex-nix-haskell/hello-world/default.nix running `nix-build --attr hello-world` . I generated default.nix using `cabal2nix . > default.nix` . You will need to rerun that whenever you add a new dependency in cabal file.