### PR TITLE
Make ‘saveEntry’ and ‘unpackInto’ restore modification time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Zip 1.1.0
+
+* Made `saveEntry` and `unpackInto` restore modification time of files.
+
 ## Zip 1.0.0
 
 * Works with `conduit-1.3.0`, `conduit-extra-1.3.0`, `resourcet-1.2.0` and

--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -352,7 +352,10 @@ saveEntry
   :: EntrySelector     -- ^ Selector that identifies archive entry
   -> FilePath          -- ^ Where to save the file
   -> ZipArchive ()
-saveEntry s path = sourceEntry s (CB.sinkFile path)
+saveEntry s path = do
+  sourceEntry s (CB.sinkFile path)
+  med <- getEntryDesc s
+  forM_ med (liftIO . setModificationTime path . edModTime)
 
 -- | Calculate CRC32 check sum and compare it with the value read from the
 -- archive. The function returns 'True' when the check sums are the

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -362,15 +362,18 @@ sinkEntrySpec =
 loadEntrySpec :: SpecWith FilePath
 loadEntrySpec =
   context "when an entry is loaded" $
-    it "is there" $ \path -> property $ \m b s -> do
+    it "is there" $ \path -> property $ \m b s t -> do
       let vpath = deriveVacant path
       B.writeFile vpath b
+      setModificationTime vpath t
       createArchive path $ do
         loadEntry m s vpath
         commit
         liftIO (removeFile vpath)
         saveEntry s vpath
       B.readFile vpath `shouldReturn` b
+      modTime <- getModificationTime vpath
+      modTime `shouldSatisfy` isCloseTo t
 
 copyEntrySpec :: SpecWith FilePath
 copyEntrySpec =


### PR DESCRIPTION
Close #25, close #26.

It looks like newer resourcet and coduit forced us to drop support for GHC 7.10 and older anyway, so now we can indeed restore modification time. This PR is a refreshed version of #26. I think we should not break the API and just start restoring modification time.

CC @jchia