### PR TITLE
add functions to set and get external file attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Zip 1.2.0
+
+* Added the `setExternalFileAttrs` function and the `edExternalFileAttrs`
+  field in the `EntryDescription` record.
+
 ## Zip 1.1.0
 
 * Made `saveEntry` and `unpackInto` restore modification time of files.

--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -121,6 +121,7 @@ module Codec.Archive.Zip
   , setModTime
   , addExtraField
   , deleteExtraField
+  , setExternalFileAttrs
   , forEntries
     -- ** Operations on archive as a whole
   , setArchiveComment
@@ -147,7 +148,7 @@ import Data.Sequence (Seq, (|>))
 import Data.Text (Text)
 import Data.Time.Clock (UTCTime)
 import Data.Void
-import Data.Word (Word16)
+import Data.Word (Word16, Word32)
 import System.Directory
 import System.FilePath ((</>))
 import System.IO.Error (isDoesNotExistError)
@@ -529,6 +530,17 @@ deleteExtraField
   -> EntrySelector     -- ^ Name of entry to modify
   -> ZipArchive ()
 deleteExtraField n s = addPending (I.DeleteExtraField n s)
+
+-- | Set external file attributes.
+--
+-- @since 1.2.0
+
+setExternalFileAttrs
+  :: Word32            -- ^ External file attributes
+  -> EntrySelector     -- ^ Name of entry to modify
+  -> ZipArchive ()
+setExternalFileAttrs attrs s =
+  addPending (I.SetExternalFileAttributes attrs s)
 
 -- | Perform an action on every entry in the archive.
 

--- a/Codec/Archive/Zip/Type.hs
+++ b/Codec/Archive/Zip/Type.hs
@@ -158,6 +158,9 @@ data EntryDescription = EntryDescription
   , edOffset           :: Natural -- ^ Absolute offset of local file header
   , edComment          :: Maybe Text -- ^ Entry comment
   , edExtraField       :: Map Word16 ByteString -- ^ All extra fields found
+  , edExternalFileAttrs :: Word32 -- ^ External file attributes
+                                  --
+                                  -- @since 1.2.0
   } deriving (Eq, Typeable)
 
 -- | Supported compression methods.


### PR DESCRIPTION
Close #51.

We provide a way to set and get the external file attributes. 

Though, many zip applications/libraries use external attributes to store the file permissions, the interpretation of these attributes are not defined by the specification itself, so as a library, we get out of the way and let the users of the library set it as per the expectations of the users of the zip file and get it while unpacking the archive and use it as the application intended.