### PR TITLE
Add Cabal flag to avoid the bzip2 C library dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * Dropped support for GHC 8.2 and older.
 
+* Added a Cabal flag `-fdisable-bzip2` to remove the bzip2 C library
+  dependency and hence support for BZip2 entries.
+
 ## Zip 1.2.0
 
 * Added the `setExternalFileAttrs` function and the `edExternalFileAttrs`

--- a/Codec/Archive/Zip/Type.hs
+++ b/Codec/Archive/Zip/Type.hs
@@ -9,6 +9,7 @@
 --
 -- Types used by the package.
 
+{-# LANGUAGE CPP                #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 
 module Codec.Archive.Zip.Type
@@ -192,6 +193,11 @@ data ZipException
     -- ^ Thrown when you try to get contents of non-existing entry
   | ParsingFailed FilePath String
     -- ^ Thrown when archive structure cannot be parsed
+#ifndef ENABLE_BZIP2
+  | BZip2Unsupported
+    -- ^ Thrown when attempting to decompress a 'BZip2' entry and the
+    -- library is compiled without support for it.
+#endif
   deriving (Eq, Ord, Typeable)
 
 instance Show ZipException where
@@ -199,5 +205,10 @@ instance Show ZipException where
     "No such entry found: " ++ show s ++ " in " ++ show file
   show (ParsingFailed file msg) =
     "Parsing of archive structure failed: \n" ++ msg ++ "\nin " ++ show file
+#ifndef ENABLE_BZIP2
+  show BZip2Unsupported =
+    "Encountered a zipfile entry with BZip2 compression, but " ++
+    "the zip library has been built with bzip2 disabled."
+#endif
 
 instance Exception ZipException

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -88,7 +88,13 @@ instance Arbitrary ByteString where
   arbitrary = B.pack <$> listOf arbitrary
 
 instance Arbitrary CompressionMethod where
-  arbitrary = elements [Store, Deflate, BZip2]
+  arbitrary = elements
+    [ Store
+    , Deflate
+#ifdef ENABLE_BZIP2
+    , BZip2
+#endif
+    ]
 
 instance Arbitrary UTCTime where
   arbitrary = UTCTime

--- a/zip.cabal
+++ b/zip.cabal
@@ -20,10 +20,14 @@ flag dev
   manual:             True
   default:            False
 
+flag disable-bzip2
+  description:         Removes dependency on bzip2 C library and hence support for BZip2 entries.
+  default:             False
+  manual:              True
+
 library
   build-depends:      base             >= 4.11    && < 5.0
                     , bytestring       >= 0.9     && < 0.11
-                    , bzlib-conduit    >= 0.3     && < 0.4
                     , case-insensitive >= 1.2.0.2 && < 1.3
                     , cereal           >= 0.3     && < 0.6
                     , conduit          >= 1.3     && < 1.4
@@ -41,6 +45,8 @@ library
                     , time             >= 1.4     && < 1.10
                     , transformers     >= 0.4     && < 0.6
                     , transformers-base
+  if !flag(disable-bzip2)
+    build-depends:    bzlib-conduit    >= 0.3     && < 0.4
   exposed-modules:    Codec.Archive.Zip
                     , Codec.Archive.Zip.CP437
   other-modules:      Codec.Archive.Zip.Internal
@@ -53,6 +59,8 @@ library
     cpp-options:      -DHASKELL_ZIP_DEV_MODE
   else
     ghc-options:      -O2 -Wall
+  if !flag(disable-bzip2)
+    cpp-options:      -DENABLE_BZIP2
   default-language:   Haskell2010
 
 test-suite tests
@@ -78,6 +86,8 @@ test-suite tests
     ghc-options:      -O0 -Wall -Werror
   else
     ghc-options:      -O2 -Wall
+  if !flag(disable-bzip2)
+    cpp-options:      -DENABLE_BZIP2
   default-language:   Haskell2010
 
 source-repository head


### PR DESCRIPTION
The bzlib-conduit library is causing us trouble when trying to cross-compile it for Windows.

The best thing to do in our case is to remove the dependency.

This change adds `-fdisable-bzip2`. Under this flag, if a caller attempts to compress or decompress a BZip2 entry, then an exception will be thrown.

Resolves #57