### PR TITLE
Ignore DoesNotExistError in removeFile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Zip 1.3.2
+
+* Fix a bug where removing a temporary file failed in the prescence of
+  async exceptions.
+
 ## Zip 1.3.1
 
 * The test suite is now faster.


### PR DESCRIPTION
We have seen a bunch of errors on CI of the form

```
C:\users\foobar\ghcBDA1.zip: DeleteFile "\\\\?\\C:\\users\\foobar\\ghcBDA1.zip": does not exist (The system cannot find the file specified.)
```

I haven’t managed to reproduce this but looking at the code it seems
like we can be interrupted with an async exception (we kill threads
pretty aggressively) in the `bracketOnError` call after the file has
been renamed but before the whole block returns. In this case, the
file will not exist but you’ll run the cleanup in `bracketOnError`
anyway which will then fail.

We could try to fix this by masking things differently but ignoring
the error seems like a simpler and more robust solution.