### PR TITLE
Fix setting archive version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## Zip 1.4.0
+
+* The “version made by” info inside archive now correctly sets Unix as the
+  OS that produced the archive when the library is compiled on Unix. This
+  allows other utilities such as `unzip` to read and correctly restore file
+  permissions. [Issue 62](https://github.com/mrkkrp/zip/issues/62).
+
 ## Zip 1.3.2
 
 * Fix a bug where removing a temporary file failed in the prescence of

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
   allows other utilities such as `unzip` to read and correctly restore file
   permissions. [Issue 62](https://github.com/mrkkrp/zip/issues/62).
 
+* Added the `Codec.Archive.Zip.Unix` module.
+
 ## Zip 1.3.2
 
 * Fix a bug where removing a temporary file failed in the prescence of

--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -532,7 +532,10 @@ deleteExtraField
   -> ZipArchive ()
 deleteExtraField n s = addPending (I.DeleteExtraField n s)
 
--- | Set external file attributes.
+-- | Set external file attributes. This function can be used to set file
+-- permissions.
+--
+-- See also: "Codec.Archive.Zip.Unix".
 --
 -- @since 1.2.0
 

--- a/Codec/Archive/Zip/Internal.hs
+++ b/Codec/Archive/Zip/Internal.hs
@@ -974,7 +974,7 @@ toVersion x = makeVersion [major, minor]
 -- specification.
 
 fromVersion :: Version -> Word16
-fromVersion v = fromIntegral (major * 10 + minor)
+fromVersion v = fromIntegral ((ZIP_OS `shiftL` 8) .|. (major * 10 + minor))
   where (major,minor) =
           case versionBranch v of
             v0:v1:_ -> (v0, v1)

--- a/Codec/Archive/Zip/Unix.hs
+++ b/Codec/Archive/Zip/Unix.hs
@@ -1,0 +1,42 @@
+-- |
+-- Module      :  Codec.Archive.Zip.Unix
+-- Copyright   :  © 2016–present Mark Karpov
+-- License     :  BSD 3 clause
+--
+-- Maintainer  :  Mark Karpov <markkarpov92@gmail.com>
+-- Stability   :  experimental
+-- Portability :  portable
+--
+-- Unix specific functionality of zip archives.
+--
+-- @since 1.4.0
+
+module Codec.Archive.Zip.Unix
+  ( toFileMode
+  , fromFileMode )
+where
+
+import Data.Bits
+import Data.Word
+import System.Posix.Types (CMode (..))
+
+-- | Convert external attributes to the file info.
+--
+-- >>> toFileMode 2179792896
+-- 0o0755
+--
+-- @since 1.4.0
+
+toFileMode :: Word32 -> CMode
+toFileMode w = CMode $ (w `shiftR` 16) .&. 0x0fff
+
+-- | Convert external attributes to the file info. The function assumes a
+-- regular file and keeps DOS attributes untouched.
+--
+-- >>> fromFileMode 0o0755
+-- 2179792896
+--
+-- @since 1.4.0
+
+fromFileMode :: CMode -> Word32
+fromFileMode (CMode c) = (0o100000 .|. c) `shiftL` 16

--- a/zip.cabal
+++ b/zip.cabal
@@ -63,6 +63,11 @@ library
     cpp-options:      -DENABLE_BZIP2
   default-language:   Haskell2010
 
+  if os(windows)
+    cpp-options:      -DZIP_OS=0
+  else
+    cpp-options:      -DZIP_OS=3
+
 test-suite tests
   main-is:            Main.hs
   hs-source-dirs:     tests

--- a/zip.cabal
+++ b/zip.cabal
@@ -49,6 +49,7 @@ library
     build-depends:    bzlib-conduit    >= 0.3     && < 0.4
   exposed-modules:    Codec.Archive.Zip
                     , Codec.Archive.Zip.CP437
+                    , Codec.Archive.Zip.Unix
   other-modules:      Codec.Archive.Zip.Internal
                     , Codec.Archive.Zip.Type
   if flag(dev)


### PR DESCRIPTION
This PR fixes setting archive version so unzip tool handles,
permissions set by the library well. In addition in introduces
the helpers for converting unix permissions into the external file
attributes value.

Fixes #62.