### PR TITLE
Set file permissions on unix platforms.

### DIFF
--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -116,11 +116,12 @@ instance Show RelPath where
 instance Arbitrary RelPath where
   arbitrary = do
     p <-
-      intercalate "/"
-        <$> listOf1
-          ( (++) <$> vectorOf 3 charGen
-              <*> listOf1 charGen
-          )
+      resize 10 $
+        intercalate "/"
+          <$> listOf1
+            ( (++) <$> vectorOf 3 charGen
+                <*> listOf1 charGen
+            )
     case mkEntrySelector p of
       Nothing -> arbitrary
       Just _ -> return (RelPath p)

--- a/zip.cabal
+++ b/zip.cabal
@@ -96,7 +96,8 @@ library
         cpp-options: -DZIP_OS=0
 
     else
-        cpp-options: -DZIP_OS=3
+        cpp-options:   -DZIP_OS=3
+        build-depends: unix <2.8
 
 executable haskell-zip-app
     main-is:          Main.hs


### PR DESCRIPTION
This commit sets user permissions on the Linux platform as follows:
  1. in case if we add an existing file to the archive we add it's
     permissions
  2. if it's a new file generated from a bytestring or a stream
     we use 0600

This behaviour mimics zip utility.

Fixes #74 

Unfortunately the amount of CPP got higher and I had to add a conditional dependency on `unix`.