### PR TITLE
Expose .Internal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Zip 2.1.0
+
+* Exposed `Codec.Archive.Zip.Internal` and `Codec.Archive.Zip.Internal.Type`
+  modules. [PR 115](https://github.com/mrkkrp/zip/pull/115).
+
 ## Zip 2.0.1
 
 * Fixed corruption of large entries when zip64 is used. [Issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * Exposed `Codec.Archive.Zip.Internal` and `Codec.Archive.Zip.Internal.Type`
   modules. [PR 115](https://github.com/mrkkrp/zip/pull/115).
 
+* Derived `Show` for `EntryDescription`. [PR
+  115](https://github.com/mrkkrp/zip/pull/115).
+
 ## Zip 2.0.1
 
 * Fixed corruption of large entries when zip64 is used. [Issue

--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -147,7 +147,7 @@ module Codec.Archive.Zip
 where
 
 import Codec.Archive.Zip.Internal qualified as I
-import Codec.Archive.Zip.Type
+import Codec.Archive.Zip.Internal.Type
 import Conduit (PrimMonad)
 import Control.Monad
 import Control.Monad.Base (MonadBase (..))

--- a/Codec/Archive/Zip/Internal.hs
+++ b/Codec/Archive/Zip/Internal.hs
@@ -13,18 +13,10 @@
 -- Portability :  portable
 --
 -- Low-level, non-public types and operations.
-module Codec.Archive.Zip.Internal
-  ( PendingAction (..),
-    targetEntry,
-    scanArchive,
-    sourceEntry,
-    crc32Sink,
-    commit,
-  )
-where
+module Codec.Archive.Zip.Internal where
 
 import Codec.Archive.Zip.CP437 (decodeCP437)
-import Codec.Archive.Zip.Type
+import Codec.Archive.Zip.Internal.Type
 import Conduit (PrimMonad)
 import Control.Applicative (many, (<|>))
 import Control.Exception (bracketOnError, catchJust)

--- a/Codec/Archive/Zip/Internal/Type.hs
+++ b/Codec/Archive/Zip/Internal/Type.hs
@@ -2,7 +2,7 @@
 {-# LANGUAGE DeriveDataTypeable #-}
 
 -- |
--- Module      :  Codec.Archive.Zip.Type
+-- Module      :  Codec.Archive.Zip.Internal.Type
 -- Copyright   :  © 2016–present Mark Karpov
 -- License     :  BSD 3 clause
 --
@@ -11,7 +11,7 @@
 -- Portability :  portable
 --
 -- Types used by the package.
-module Codec.Archive.Zip.Type
+module Codec.Archive.Zip.Internal.Type
   ( -- * Entry selector
     EntrySelector,
     mkEntrySelector,

--- a/Codec/Archive/Zip/Internal/Type.hs
+++ b/Codec/Archive/Zip/Internal/Type.hs
@@ -170,7 +170,7 @@ data EntryDescription = EntryDescription
     -- @since 1.2.0
     edExternalFileAttrs :: Word32
   }
-  deriving (Eq, Typeable)
+  deriving (Eq, Typeable, Show)
 
 -- | The supported compression methods.
 data CompressionMethod

--- a/tests/Main.hs
+++ b/tests/Main.hs
@@ -204,22 +204,6 @@ binASCII = LB.toStrict . LB.toLazyByteString <$> go
           (1, return mempty)
         ]
 
-instance Show EntryDescription where
-  show ed =
-    "{ edCompression = "
-      ++ show (edCompression ed)
-      ++ "\n, edModTime = "
-      ++ show (edModTime ed)
-      ++ "\n, edUncompressedSize = "
-      ++ show (edUncompressedSize ed)
-      ++ "\n, edComment = "
-      ++ show (edComment ed)
-      ++ "\n, edExtraField = "
-      ++ show (edExtraField ed)
-      ++ "\n, edExtFileAttr = "
-      ++ show (edExternalFileAttrs ed)
-      ++ " }"
-
 instance Show (ZipArchive a) where
   show = const "<zip archive>"
 

--- a/zip.cabal
+++ b/zip.cabal
@@ -44,10 +44,8 @@ library
         Codec.Archive.Zip
         Codec.Archive.Zip.CP437
         Codec.Archive.Zip.Unix
-
-    other-modules:
         Codec.Archive.Zip.Internal
-        Codec.Archive.Zip.Type
+        Codec.Archive.Zip.Internal.Type
 
     default-language: GHC2021
     build-depends:


### PR DESCRIPTION
Hi, thanks for the library!

We're implementing low-level IO improvements for ZIP files of a specific shape, in particular to work around https://gitlab.haskell.org/ghc/ghc/-/issues/24220 on networked file systems.

For that to work, we need the `internal` modules exposed; this PR upstreams that. It will also help others who want to use the lower-level parts of this library.

Thank you!