### PR TITLE
Install bzip2 on the Ubuntu latest runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: haskell-actions/run-ormolu@v14
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs: ormolu
     strategy:
       matrix:


### PR DESCRIPTION
This should not be necessary, however in practice since recently Cabal cannot find bzip2, it complains:

* Missing (or bad) C library: bz2