### PR TITLE
Build bzlib-conduit with a bundled bzip2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,6 +29,9 @@ jobs:
         with:
           ghc-version: ${{ matrix.ghc }}
           cabal-version: ${{ matrix.cabal }}
+      - run: |
+          echo 'packages: .' > cabal.project
+          echo 'constraints: bzlib-conduit -system-bzip2' >> cabal.project
       - run: cabal update
       - run: cabal freeze $CONFIG
       - uses: actions/cache@v3.3.1


### PR DESCRIPTION
For some inexplicable reason recent ubuntu-latest runners do not provide bzip2 in a way that Cabal is happy with. This used to work…