### PR TITLE
Skip Zip64 extra fields when strict input doesn't require it.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unpublished
+
+* Skip the addition of Zip64 extra fields when sufficiently short strict
+  input is provided (e.g. via `addEntry`). [Issue
+  126](https://github.com/mrkkrp/zip/issues/126).
+
 ## Zip 2.1.0
 
 * Exposed `Codec.Archive.Zip.Internal` and `Codec.Archive.Zip.Internal.Type`

--- a/Codec/Archive/Zip.hs
+++ b/Codec/Archive/Zip.hs
@@ -431,7 +431,7 @@ addEntry ::
   -- | Name of the entry to add
   EntrySelector ->
   ZipArchive ()
-addEntry t b s = addPending (I.SinkEntry t (C.yield b) s)
+addEntry t b s = addPending (I.StrictEntry t b s)
 
 -- | Stream data from the specified source to an archive entry.
 sinkEntry ::

--- a/Codec/Archive/Zip/Internal.hs
+++ b/Codec/Archive/Zip/Internal.hs
@@ -495,9 +495,7 @@ sinkEntry h s o src EditingActions {..} = do
       modTime = case o of
         GenericOrigin -> currentTime
         Borrowed ed -> edModTime ed
-      extFileAttr = case o of
-        GenericOrigin -> M.findWithDefault defaultFileMode s eaExtFileAttr
-        Borrowed _ -> M.findWithDefault defaultFileMode s eaExtFileAttr
+      extFileAttr = M.findWithDefault defaultFileMode s eaExtFileAttr
       oldExtraFields = case o of
         GenericOrigin -> M.empty
         Borrowed ed -> edExtraField ed


### PR DESCRIPTION
Close #126.

When entry data is provided as a strict `ByteString`, we don't need to stream any data to determine its uncompressed size. Thus, we can rule out the need for Zip64 extra fields early when writing the local header. This applies mainly to `addEntry`, which takes its input as a strict `ByteString`.

In summary, I added a new `PendingAction` called `StrictEntry` and a new `EntryOrigin` (`StrictOrigin Int`) which tracks the size of strict data for use when building the header. I decided to pass that to `putHeader` as part of the `LocalHeader` `HeaderType` because the information is only really relevant when writing the local header (nothing is different for the CD headers).

I also made some additional minor code simplifications that don't change any behavior. Some Maps were being iterated over many times because of a combination of `forM_` and `(!)` from `Data.Map.Strict`. My change reduces those to a single pass where possible while avoiding `(!)`, which is no longer recommended.

All the tests are passing for me.